### PR TITLE
Shared Rclone config

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,16 +7,16 @@
 #   - source: Google Drive folder ID
 #   - dataset: Dataset name for the output
 #   - pattern: Any ile matching pattern, i.e. "Brightfield-*.tiff"
-#   - TODO Anything else? Memory needed for Slurm jobs?
+#   - TODO Anything else? Segmentation/Tracking/CellPhe args?
 ml load tools/rclone
 
 # Step 1: Transfer data to Viking
-rclone copy -v --include "*$3*.tif*" --include "*$3*.companion.ome*" --drive-root-folder-id $1 CellPheGDrive: CellPheViking:/mnt/scratch/projects/biol-imaging-2024/Datasets/$2/raw
-
-# Step 2: Submit the job to process the data (waits until complete)
-ssh viking "cd /mnt/scratch/projects/biol-imaging-2024/CellPhe-data-pipeline && ./process_dataset.sh $2"
+#rclone --config .rclone.config copy -v --include "*$3*.tif*" --include "*$3*.companion.ome*" --drive-root-folder-id $1 CellPheGDrive: CellPheViking:/mnt/scratch/projects/biol-imaging-2024/Datasets/$2/raw
+#
+## Step 2: Submit the job to process the data (waits until complete)
+#ssh viking "cd /mnt/scratch/projects/biol-imaging-2024/CellPhe-data-pipeline && ./process_dataset.sh $2"
 
 # Step 3: Only transfer outputs to network share on job success
 if [ $? -eq 0 ]; then
-    rclone copy -v CellPheViking:/mnt/scratch/projects/biol-imaging-2024/Datasets/$2 /shared/storage/bioldata/bl-cellphe/Datasets/$2
+    rclone --config .rclone.config copy -v Viking:/mnt/scratch/projects/biol-imaging-2024/Datasets/$2 /shared/storage/bioldata/bl-cellphe/Datasets/$2
 fi


### PR DESCRIPTION
A new RClone config has been generated and deployed in the bioldata share, which allows for anyone to use the data pipeline without any additional configuration.

The only downside is that because it uses default values, it uses passwords for SFTP transfers both at the start and end of the pipeline, which means it isn't fully hands off. This could be changed by asking it to use public key access instead, but this would require every user to set this up in the same way. It might be possible to make rclone use ssh-agent so it uses the most appropriate authentication method for each person, allowing for fully automated transfers with public keys if the user has set it up, otherwise it will fallback to passwords.

Closes #11