### PR TITLE
Handle JVM out-of-memory error

### DIFF
--- a/bin/track_images.py
+++ b/bin/track_images.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from cellphe import track_images
 import argparse
+import sys
 
 parser = argparse.ArgumentParser(
                     description='Tracks a given image'
@@ -14,11 +15,14 @@ args = parser.parse_args()
 # Comes through as 'X GB' from Nextflow, obtain the number
 requested_memory = int(args.memory.split(" ")[0])
 
-track_images(
-    mask_dir = args.mask_dir,
-    csv_filename = args.csv_filename,
-    roi_filename = args.roi_filename,
-    tracker = "SimpleSparseLAP",
-    tracker_settings = None,
-    max_heap=requested_memory
-)
+try:
+    track_images(
+        mask_dir = args.mask_dir,
+        csv_filename = args.csv_filename,
+        roi_filename = args.roi_filename,
+        tracker = "SimpleSparseLAP",
+        tracker_settings = None,
+        max_heap=requested_memory
+    )
+except Exception:  # Assume OOM - scyjava doesn't make it possible to specify which Java error was thrown
+    sys.exit(125)  # Slurm out-of-memory


### PR DESCRIPTION
While the NextFlow pipeline will automatically retry any jobs that fail with the out-ofmemory Slurm exit code, this exit code isn't thrown from any programs that exit due to the JVM running out-of-memory. This fixes that.