### PR TITLE
Use a venv from the project folder rather than a personal one

### DIFF
--- a/process_dataset.sh
+++ b/process_dataset.sh
@@ -7,5 +7,5 @@ ml load Nextflow/23.10.0
 ml load Java/11.0.20
 ml load Perl-bundle-CPAN/5.38.0-GCCcore-13.2.0
 ml load LibTIFF/4.6.0-GCCcore-13.2.0
-source ~/venvs/cellphe/bin/activate
+source /mnt/scratch/projects/biol-imaging-2024/venv/bin/activate
 nextflow run process_dataset.nf --dataset $1


### PR DESCRIPTION
This allows anyone in the project to run the pipeline rather than requiring everyone to setup the venv in their corresponding home directories.