### PR TITLE
hotfix: Tell CellPose to use project-wide model folder

### DIFF
--- a/process_dataset.sh
+++ b/process_dataset.sh
@@ -13,6 +13,7 @@ ml load Perl-bundle-CPAN/5.38.0-GCCcore-13.2.0
 ml load LibTIFF/4.6.0-GCCcore-13.2.0
 ml load ImageMagick/7.1.1-34-GCCcore-13.2.0
 source /mnt/scratch/projects/biol-imaging-2024/venv/bin/activate
+export CELLPOSE_LOCAL_MODELS_PATH=/mnt/scratch/projects/biol-imaging-2024/cellpose
 
 CMD="srun --ntasks=1 --cpus-per-task 4 --mem=8G --time=120 nextflow run process_dataset.nf -work-dir ../Datasets/$DATASET/.work --dataset $DATASET"
 if [ $MODEL != 'default' ]


### PR DESCRIPTION
By default models are saved in the user's home directory, which meant the pipeline wasn't working for users other than me. This change tells CellPose to instead use a project folder.

This wasn't the direct cause of #28 , which I believe is instead a permissions issue, but should help ensure we're all using the same models.