### PR TITLE
feat: Generate QC report for segmentation

### DIFF
--- a/bin/segmentation_qc.qmd
+++ b/bin/segmentation_qc.qmd
@@ -9,7 +9,7 @@ execute:
   warning: false
   message: false
 params:
-    files: "/mnt/cellphe/Datasets/2024-11-13-iolight-M231_low_NA_aligned/masks/frame_00001_mask.png /mnt/cellphe/Datasets/2024-11-13-iolight-M231_low_NA_aligned/masks/frame_00002_mask.png /mnt/cellphe/Datasets/2024-11-13-iolight-M231_low_NA_aligned/masks/frame_00003_mask.png"
+    files: ""
 ---
 
 ```{python setup_python}

--- a/process_dataset.nf
+++ b/process_dataset.nf
@@ -35,16 +35,15 @@ process segmentation_qc {
     publishDir "../Datasets/${params.dataset}/QC", mode: 'copy'
 
     input:
+    path notebook
     path input_files
 
     output:
-    path "segmentation_masks_stitched.png"
-    path "segmentation_cells_per_frame.png"
-    path "segmentation_cells_area.png"
+    path "segmentation_qc.html"
 
     script:
     """
-    segmentation_qc.py "${input_files}"
+    quarto render ${notebook} -P files:"${input_files}"
     """
 }
 
@@ -393,7 +392,11 @@ workflow {
     // Segment all images and track
     masks = segment_image(allFiles)
       | collect
-    segmentation_qc(masks)
+    segmentation_qc(
+        file('/mnt/scratch/projects/biol-imaging-2024/CellPhe-data-pipeline/bin/segmentation_qc.qmd'),
+        masks
+    )
+
     track_images(masks)
       | parse_trackmate_xml
 
@@ -403,7 +406,7 @@ workflow {
     // a shebang like all the other files in bin/
     tracking_qc(
         file('/mnt/scratch/projects/biol-imaging-2024/CellPhe-data-pipeline/bin/tracking_qc.qmd'),
-	parse_trackmate_xml.out.features,
+        parse_trackmate_xml.out.features,
         trackmate_feats
     )
 


### PR DESCRIPTION
Turns the Segmentation QC from a Python script into a Quarto notebook.
This consolidates all QC outputs into a single file, making it easier to modify as well as read.
Using a Quarto notebook also allows for the use of interactive plots (through JS libraries such as plotly) as well as having textual summaries to provide more context to the figures, rather than having them standalone.

Closes #40 