### PR TITLE
feat: Move files when renaming rather than copying

### DIFF
--- a/process_dataset.nf
+++ b/process_dataset.nf
@@ -314,7 +314,7 @@ process rename_frames {
     raw_fns = "${in_files}".split(" ")
     for i, raw_fn in enumerate(sorted(raw_fns)):
         new_fn = f"frame_{i+1:05}.tiff"
-        shutil.copy2(raw_fn, new_fn)
+        shutil.move(raw_fn, new_fn)
     """
 }
 


### PR DESCRIPTION
As part of the standardisation process to ensure all images are named in the same way, the images are renamed to the format `frame_XXXX.tiff`, where XXXX is a zero-padded integer.

This was previously done by copying the files, as I didn't want to alter the originals. However, this was before I fully understood how Nextflow handles filepaths, as it creates a symlink for any file mentioned, rather than use it directly. Thus, renaming the raw 'file' actually just renames a symlink.

This speeds up the renaming process considerably, which is becoming noticeable for larger datasets, and it saves storage space of an additional copy of the dataset. This data is saved in the `.work` dir which is periodically deleted, but anything to help keep within our quota is worth doing, especially when it's a single function call change like this.