### PR TITLE
feat: Handle tomocube images

### DIFF
--- a/process_dataset.nf
+++ b/process_dataset.nf
@@ -432,8 +432,16 @@ workflow {
 
     // Remove spaces as that messes up collecting
     // Then rename images to standard frame_XXXX.tiff format
-    allFiles = frameFiles
+    frameFiles
+        .branch { f ->
+            has_space: f.getBaseName().contains(" ")
+            no_space: true
+        }
+        .set { filesBranched }
+
+    allFiles = filesBranched.has_space
       | remove_spaces
+      | concat(filesBranched.no_space)
       | collect
       | rename_frames
       | flatten
@@ -448,7 +456,7 @@ workflow {
             masks,
             allFiles.collect()
         )
-	if (params.run.tracking) {
+        if (params.run.tracking) {
 
             track_images(masks)
               | parse_trackmate_xml


### PR DESCRIPTION
The TIFFs that we have obtained from the Tomocube have 2 awkward filename properties that we haven't encountered previously, but are still valid filenames:

  - They contain spaces
  - They don't zero pad the frame number

The first breaks the `flatten` Nextflow operator, which combines multiple filenames into a single string to pass into processes, delimited by spaces. The process can then split this string on spaces to obtain the individual filenames.
However, this doesn't work if the filenames themselves contain spaces, which the Tomocube ones do.

So far all microscopes output filenames that when sorted in lexicographic order are also sorted chronologically.
This is generally achieved by either using a timestamp, or zero-padding a frame index.
However, the Tomocube uses a non-zero padded frame number, so that when sorted lexicographically frame '10' is considered to come before frame '2'.

The second issue is fixed by using the `natsort` Python package, which provides an algorithm to 'naturally' sort strings, handling this use case.

The first issue has been attempted to be resolved by using the `rename` Linux utility, however, this isn't currently working, and I'm not sure why, as there's 2 potential issues at play.
The first is that `rename` raises an error (exit code = 4) when the file wasn't renamed (i.e. there wasn't a space in it), so we need to tell Nextflow to ignore errors in this process.
The second is that if the file isn't renamed, by default Nextflow doesn't view it as a valid output, since it's the same as the input. There is a flag 'includeInputs' which should mean that the input file is viewed as an output since it matches the glob.
Because of either of these reasons, or their combined effect, this process doesn't produce any outputs when files don't have spaces in, so the rest of the pipeline terminates.
I have a hunch it's the second reason that causes this problem, see [this issue](https://github.com/nextflow-io/nextflow/issues/1551) in the Nextflow repo.
To test this, I'll try renaming the file using an alternative way that doesn't throw an error if the file doesn't change, which will narrow the potential causes down to the symlink case.
I can then use that Issue to seek help.

There is also the slight matter that Brightfield images aren't valid TIFFs, as the pixel values are encoded as floats, despite the image metadata specifying it is in 8-bit resolution.
I'm going to ask support from the Tomocube technician, as this might be caused by the exporting method, and not something to solve at our end.

- [x] Remove spaces
- [x] Handle non-zero-padded filenames
- [x] Handle the Brightfield images