### PR TITLE
hotfix: Remove all spaces in filename

### DIFF
--- a/process_dataset.nf
+++ b/process_dataset.nf
@@ -336,7 +336,8 @@ process remove_spaces {
 
   script:
   """
-  rename ' ' '_' ${in_file}
+  out_file=\$(echo ${in_file} | sed 's/ /_/g')
+  mv $in_file \$out_file
   """
 }
 


### PR DESCRIPTION
The `rename` Linux utility program (not the Perl one) was previously used to remove spaces from filenames. However, this only works for the **first** occurrence of the pattern in the file, not **all** occurrences.
To replace all spaces with underscores, `sed` and `mv` are used instead.