### PR TITLE
feat: Run Pipeline using source data on bioldata

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,11 +28,6 @@ SOURCE=${@:$OPTIND:1}
 PATTERN=${@:$OPTIND+1:1}
 CONFIG=${@:$OPTIND+2:1}
 
-echo "Source = $SOURCE"
-echo "Pattern = $PATTERN"
-echo "Config = $CONFIG"
-echo "bioldata = $bioldata"
-
 # Validate the provided config file
 EXPERIMENT="$(basename $(dirname $(dirname ${CONFIG})))"
 CONFIG_DIR="$(basename $(dirname ${CONFIG}))"


### PR DESCRIPTION
Previously the launching script required raw data to be stored on Google
Drive. It is now more flexible and can handle a path to a folder
containing the data on bioldata instead, along with the `-b` flag.