### PR TITLE
feat: Save image stacks as ZIP of frames

### DIFF
--- a/process_dataset.nf
+++ b/process_dataset.nf
@@ -9,7 +9,7 @@ params.run = ''
 // Folder paths
 timelapse_id = "${params.folder_names.site}_${params.folder_names.image_type}"
 raw_dir = "../../raw/${timelapse_id}"
-processed_dir = "../../processed/${timelapse_id}"
+processed_dir = "../../processed"
 seg_dir = "../../analysis/segmentation/${params.folder_names.segmentation}"
 mask_dir = "${seg_dir}/masks/${timelapse_id}"
 track_dir = "${seg_dir}/tracking/${params.folder_names.tracking}"
@@ -387,19 +387,19 @@ process split_stacked_tiff {
 process create_tiff_stack {
     label 'slurm'
     time 30.minute
-    memory 16.GB
-    publishDir "${processed_dir}", mode: 'copy'
+    memory 8.GB
+    publishDir "${processed_dir}", mode: 'move'
     errorStrategy 'ignore'
 
     input:
     path(frames) 
 
     output:
-    path "frames_stacked.tiff"
+    path "${timelapse_id}.zip"
 
     script:
     """
-    tiffcp ${frames} frames_stacked.tiff
+    zip "${timelapse_id}.zip" ${frames}
     """
 }
 


### PR DESCRIPTION
This has several benefits over the image stacks:

  - Brightfield images (which are larger than Phase) didn't fit into the 4GB tiff limit
  - Saves on space over tiff stack
  - To view a single frame in ImageJ you don't need to open the entire stack