### PR TITLE
Added template for Tomocube using cyto3 with 150 diameter

### DIFF
--- a/templates/tomocube_cyto3_150diameter.json
+++ b/templates/tomocube_cyto3_150diameter.json
@@ -1,0 +1,47 @@
+{
+  "folder_names": {
+    "site": "",
+    "image_type": "HT2D",
+    "segmentation": "cyto3_diameter_150",
+    "tracking": "LAP_default"
+  },
+  "run": {
+    "segmentation": true,
+    "tracking": true,
+    "cellphe": true
+  },
+  "segmentation": {
+    "model": {
+      "model_type": "cyto3"
+    },
+    "eval": {
+      "channels": [0,0],
+      "diameter": 150
+    }
+  },
+  "tracking": {
+    "algorithm": "SparseLAP",
+    "settings": {
+      "LINKING_MAX_DISTANCE": 70.0,
+      "LINKING_FEATURE_PENALTIES": {},
+      "ALLOW_GAP_CLOSING": true,
+      "MAX_FRAME_GAP": 4,
+      "GAP_CLOSING_MAX_DISTANCE": 90.0,
+      "GAP_CLOSING_FEATURE_PENALTIES": {},
+      "ALLOW_TRACK_MERGING": true,
+      "MERGING_MAX_DISTANCE": 50.0,
+      "MERGING_FEATURE_PENALTIES": {
+        "AREA": 0.5
+      },
+      "ALLOW_TRACK_SPLITTING": true,
+      "SPLITTING_MAX_DISTANCE": 5.0,
+      "SPLITTING_FEATURE_PENALTIES": {},
+      "ALTERNATIVE_LINKING_COST_FACTOR": 1.05,
+      "CUTOFF_PERCENTILE": 0.9
+    }
+  },
+  "QC": {
+    "minimum_observations": 50,
+    "minimum_cell_size": 50
+  }
+}


### PR DESCRIPTION
This will allow consistent Tomocube segmentation across experiments. This is currently the most accurate segmentation setup we have.