### PR TITLE
feat: Added template for OpenFlexure timelapses

### DIFF
--- a/templates/openflexure_20260114.json
+++ b/templates/openflexure_20260114.json
@@ -1,0 +1,49 @@
+{
+  "folder_names": {
+    "timelapse_id": "",
+    "segmentation": "openflexure_20260114",
+    "tracking": "LAP_default"
+  },
+  "run": {
+    "segmentation": true,
+    "tracking": true,
+    "cellphe": true
+  },
+  "segmentation": {
+    "image": "ghcr.io/uoy-research/cellphe-cellpose3:0.1.3",
+    "model": {
+      "pretrained_model": "/cellpose/CP_OFM_20260114",
+      "gpu": false
+    },
+    "eval": {
+      "channels": [0,0],
+      "flow_threshold": 0.6
+    }
+  },
+  "tracking": {
+    "algorithm": "SparseLAP",
+    "settings": {
+      "LINKING_MAX_DISTANCE": 70.0,
+      "LINKING_FEATURE_PENALTIES": {},
+      "ALLOW_GAP_CLOSING": true,
+      "MAX_FRAME_GAP": 4,
+      "GAP_CLOSING_MAX_DISTANCE": 90.0,
+      "GAP_CLOSING_FEATURE_PENALTIES": {},
+      "ALLOW_TRACK_MERGING": true,
+      "MERGING_MAX_DISTANCE": 50.0,
+      "MERGING_FEATURE_PENALTIES": {
+        "AREA": 0.5
+      },
+      "ALLOW_TRACK_SPLITTING": true,
+      "SPLITTING_MAX_DISTANCE": 5.0,
+      "SPLITTING_FEATURE_PENALTIES": {},
+      "ALTERNATIVE_LINKING_COST_FACTOR": 1.05,
+      "CUTOFF_PERCENTILE": 0.9
+    }
+  },
+  "QC": {
+    "minimum_observations": 50,
+    "minimum_cell_size": 50,
+    "segmentation_highlight": "outline"
+  }
+}


### PR DESCRIPTION
Added a config template for OpenFlexure timelapses that:

  - Uses the latest version of the [`cellpose3` image](https://github.com/uoy-research/cellphe-pipeline-images/pkgs/container/cellphe-cellpose3)
  - Uses the OpenFlexure model image that is baked into the image
  - Sets `flow_threshold=0.6` as this was identified to perform better for OpenFlexure images